### PR TITLE
CLI to use utf-8 encoding

### DIFF
--- a/pycsvw/scripts/cli.py
+++ b/pycsvw/scripts/cli.py
@@ -45,7 +45,7 @@ def main(csv_url, csv_path, metadata_url, metadata_path, json_dest, rdf_dest, te
         for form, dest in rdf_dest:
             rdf_output = csvw.to_rdf(form)
             with open(dest, "w") as rdf_file:
-                rdf_file.write(rdf_output)
+                rdf_file.write(rdf_output.encode('utf-8'))
         if json_dest:
             json_output = csvw.to_json()
             with open(json_dest, "w") as json_file:

--- a/pycsvw/scripts/cli.py
+++ b/pycsvw/scripts/cli.py
@@ -11,6 +11,7 @@
 
 """ Command line interface for pycsvw """
 import json
+import io
 
 import click  # pylint: disable=import-error
 
@@ -44,7 +45,7 @@ def main(csv_url, csv_path, metadata_url, metadata_path, json_dest, rdf_dest, te
 
         for form, dest in rdf_dest:
             rdf_output = csvw.to_rdf(form)
-            with open(dest, "w") as rdf_file:
+            with io.open(dest, "wb") as rdf_file:
                 rdf_file.write(rdf_output.encode('utf-8'))
         if json_dest:
             json_output = csvw.to_json()

--- a/tests/test_command_line_options.py
+++ b/tests/test_command_line_options.py
@@ -72,11 +72,13 @@ def test_main_using_urls(mock_urlopen):
         assert result.exit_code == 0
 
 
+def test_non_ascii_characters():
+    csv_path = "tests/utf8_encoding.csv"
+    metadata_path = "tests/utf8_encoding.csv-metadata.json"
 
+    runner = CliRunner()
 
-
-
-
-
-
-
+    result = runner.invoke(main, ["--csv-path", csv_path,
+                                  "--metadata-path", metadata_path,
+                                  "--rdf-dest", "turtle", "/dev/null"])
+    assert result.exit_code == 0

--- a/tests/utf8_encoding.csv
+++ b/tests/utf8_encoding.csv
@@ -1,0 +1,2 @@
+id,name,type,unit
+1,new car mode,µsedan,µ100

--- a/tests/utf8_encoding.csv-metadata.json
+++ b/tests/utf8_encoding.csv-metadata.json
@@ -1,0 +1,50 @@
+{
+  "@context": [
+    "http://www.w3.org/ns/csvw", {
+      "car": "http://example.org/cars/",
+      "unit": "http://example.org/units/",
+      "meta": "http://example.org/properties/"
+  	}
+  ],
+  "tables": [
+    {
+      "url": "utf8_encoding.csv",
+      "tableSchema": {
+        "aboutUrl": "car:{id}",
+        "primaryKey": "{id}",
+        "columns": [
+          {
+            "name": "id",
+            "propertyUrl": "meta:id",
+            "datatype": "token",
+            "required": true
+          },
+          {
+            "name": "name",
+            "propertyUrl": "meta:name",
+            "datatype": "string",
+            "required": true
+          },
+          {
+            "name": "type",
+            "propertyUrl": "meta:type",
+            "datatype": "enumeration",
+            "required": false
+          },
+          {
+            "name": "unit",
+            "datatype": "string",
+            "suppressOutput": true,
+            "required": false
+          },
+          {
+            "virtual": true,
+            "propertyUrl": "meta:UnitOfMeasurement",
+            "valueUrl": "unit:{unit}",
+            "required": false
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Tests with tox are passing:

======================================================================== test session starts ========================================================================
platform linux2 -- Python 2.7.5, pytest-3.2.2, py-1.4.34, pluggy-0.4.0
rootdir: /home/ekorkut1/pycsvw, inifile:
collected 57 items                                                                                                                                                   

tests/test_command_line_options.py ...
tests/test_encoding.py .
tests/test_negative.py ......
tests/test_parsing.py ..
tests/examples/rdf/test_events_listing_rdf.py .
tests/examples/rdf/test_group_of_files.py .
tests/examples/rdf/test_tree_ops_ext_rdf.py .
tests/rdf/test_datatypes.py ......
tests/rdf/test_empty_values.py ..
tests/rdf/test_formats.py .........
tests/rdf/test_multiple_tables.py ...
tests/rdf/test_new_lines_and_escapes.py ..
tests/rdf/test_null_values.py ..
tests/rdf/test_rdf_negative.py ......
tests/rdf/test_single_table.py ...
tests/rdf/test_value_urls_rdf.py ..
tests/rdf/test_virtual_columns.py .......

==================================================================== 57 passed in 48.89 seconds =====================================================================
py34 inst-nodeps: /home/ekorkut1/pycsvw/.tox/dist/pycsvw-1.0.0.zip
py34 installed: click==6.7,future==0.16.0,isodate==0.5.4,mock==2.0.0,pbr==3.1.1,py==1.4.34,pycsvw==1.0.0,pyparsing==2.2.0,pytest==3.2.2,python-dateutil==2.6.1,rdflib==4.2.2,rdflib-jsonld==0.4.0,six==1.11.0
py34 runtests: PYTHONHASHSEED='2481463967'
py34 runtests: commands[0] | python -m pytest tests
======================================================================== test session starts ========================================================================
platform linux -- Python 3.4.5, pytest-3.2.2, py-1.4.34, pluggy-0.4.0
rootdir: /home/ekorkut1/pycsvw, inifile:
collected 57 items                                                                                                                                                   

tests/test_command_line_options.py ...
tests/test_encoding.py .
tests/test_negative.py ......
tests/test_parsing.py ..
tests/examples/rdf/test_events_listing_rdf.py .
tests/examples/rdf/test_group_of_files.py .
tests/examples/rdf/test_tree_ops_ext_rdf.py .
tests/rdf/test_datatypes.py ......
tests/rdf/test_empty_values.py ..
tests/rdf/test_formats.py .........
tests/rdf/test_multiple_tables.py ...
tests/rdf/test_new_lines_and_escapes.py ..
tests/rdf/test_null_values.py ..
tests/rdf/test_rdf_negative.py ......
tests/rdf/test_single_table.py ...
tests/rdf/test_value_urls_rdf.py ..
tests/rdf/test_virtual_columns.py .......

==================================================================== 57 passed in 47.48 seconds =====================================================================
______________________________________________________________________________ summary ______________________________________________________________________________
  py27: commands succeeded
  py34: commands succeeded
  congratulations :)



